### PR TITLE
Rename columns of filename and layer to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ FROM ST_Read_Multi('test/data/*.geojson');
 
 ```
 ┌─────────────────┬────────┬─────────┬───────────────────────────┐
-│    geometry     │  val1  │  val2   │         filename          │
+│    geometry     │  val1  │  val2   │         .filename         │
 │    geometry     │ double │ varchar │          varchar          │
 ├─────────────────┼────────┼─────────┼───────────────────────────┤
 │ POINT (1 2)     │    1.0 │ a       │ test/data/points.geojson  │
@@ -58,7 +58,7 @@ FROM ST_Read_Multi('test/data/*.gpkg');
 
 ```
 ┌─────────────────┬───────┬─────────┬─────────────────────────────┬───────────────┐
-│      geom       │ val1  │  val2   │          filename           │     layer     │
+│      geom       │ val1  │  val2   │          .filename          │    .layer     │
 │    geometry     │ int32 │ varchar │           varchar           │    varchar    │
 ├─────────────────┼───────┼─────────┼─────────────────────────────┼───────────────┤
 │ POINT (100 200) │     5 │ c       │ test/data/multi_layers.gpkg │ points2_point │
@@ -81,7 +81,7 @@ FROM ST_Read_Multi('test/data/*.gpkg', layer='points');
 ```
 [WARN] No such layer 'points' in test/data/multi_layers.gpkg
 ┌─────────────────┬───────┬─────────┬────────────────────────┬─────────┐
-│      geom       │ val1  │  val2   │        filename        │  layer  │
+│      geom       │ val1  │  val2   │       .filename        │ .layer  │
 │    geometry     │ int32 │ varchar │        varchar         │ varchar │
 ├─────────────────┼───────┼─────────┼────────────────────────┼─────────┤
 │ POINT (1 2)     │     1 │ a       │ test/data/points.gpkg  │ points  │

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@ use crate::{
 // but use a fixed value here.
 pub(crate) const VECTOR_SIZE: usize = 2048;
 
+const COLUMN_NAME_FILENAME: &str = ".filename";
+const COLUMN_NAME_LAYER: &str = ".layer";
+
 struct StReadMultiVTab;
 
 impl VTab for StReadMultiVTab {
@@ -81,7 +84,7 @@ impl VTab for StReadMultiVTab {
             }
 
             // filename column to track source file
-            bind.add_result_column("filename", LogicalTypeId::Varchar.into());
+            bind.add_result_column(COLUMN_NAME_FILENAME, LogicalTypeId::Varchar.into());
 
             return Ok(GeoJsonBindData {
                 sources,
@@ -123,8 +126,8 @@ impl VTab for StReadMultiVTab {
             }
 
             // filename and layer column to track source
-            bind.add_result_column("filename", LogicalTypeId::Varchar.into());
-            bind.add_result_column("layer", LogicalTypeId::Varchar.into());
+            bind.add_result_column(COLUMN_NAME_FILENAME, LogicalTypeId::Varchar.into());
+            bind.add_result_column(COLUMN_NAME_LAYER, LogicalTypeId::Varchar.into());
 
             return Ok(GpkgBindData {
                 sources,

--- a/test/sql/st_read_multi.test
+++ b/test/sql/st_read_multi.test
@@ -38,7 +38,7 @@ POINT (111 222)	6.0	d
 
 # multi-layer Gpkg file
 query IIII
-SELECT ST_GeomFromWkb(geom), val1, val2, layer FROM ST_Read_Multi('test/data/multi_layers.gpkg');
+SELECT ST_GeomFromWkb(geom), val1, val2, ".layer" FROM ST_Read_Multi('test/data/multi_layers.gpkg');
 ----
 POINT (100 200)	5.0	c	points2_point
 POINT (111 222)	6.0	d	points2_point
@@ -47,7 +47,7 @@ POINT (10 20)	 2.0	b	points_point
 
 # multiple Gpkg files with layer filtering
 query IIII
-SELECT ST_GeomFromWkb(geom), val1, val2, parse_filename(filename) FROM ST_Read_Multi('test/data/*.gpkg', layer='points');
+SELECT ST_GeomFromWkb(geom), val1, val2, parse_filename(".filename") FROM ST_Read_Multi('test/data/*.gpkg', layer='points');
 ----
 POINT (1 2)	 1.0	a	points.gpkg
 POINT (10 20)	 2.0	b	points.gpkg


### PR DESCRIPTION
This is not perfect. The column names can still conflict if the data has the column named `layer` or `filename`, but this change should make it less frequent.

Close #6 (this does not really fixes the issue properly, but probably this is enough for now...)